### PR TITLE
Improve ALSA MIDI backend

### DIFF
--- a/source/mididevices/music_alsa_mididevice.cpp
+++ b/source/mididevices/music_alsa_mididevice.cpp
@@ -289,8 +289,8 @@ EventType AlsaMIDIDevice::PullEvent(EventState & state) {
 			return EventType::Action;
 
 		case MIDI_POLYPRESS:
-			// FIXME: Seems to be missing in the Alsa sequencer implementation
-			break;
+			snd_seq_ev_set_keypress(&state.data, channel, parm1, parm2);
+			return EventType::Action;
 
 		case MIDI_CTRLCHANGE:
 			snd_seq_ev_set_controller(&state.data, channel, parm1, parm2);
@@ -427,7 +427,6 @@ void AlsaMIDIDevice::PumpEvents() {
 		snd_seq_drain_output(sequencer.handle);
 		snd_seq_sync_output_queue(sequencer.handle);
 	}
-	snd_seq_sync_output_queue(sequencer.handle);
 	snd_seq_stop_queue(sequencer.handle, QueueId, NULL);
 	snd_seq_drain_output(sequencer.handle);
 }

--- a/source/mididevices/music_alsa_state.cpp
+++ b/source/mididevices/music_alsa_state.cpp
@@ -67,7 +67,7 @@ bool AlsaSequencer::Open() {
 	if(error) {
 		return false;
 	}
-	error = snd_seq_set_client_name(handle, "GZDoom");
+	error = snd_seq_set_client_name(handle, "ZMusic Program");
 	if(error) {
 		snd_seq_close(handle);
 		handle = nullptr;
@@ -131,11 +131,7 @@ int AlsaSequencer::EnumerateDevices() {
 	while (snd_seq_query_next_client(handle, cinfo) >= 0) {
 		snd_seq_port_info_set_client(pinfo, snd_seq_client_info_get_client(cinfo));
 
-		// Ignore 'ALSA oddities' that we don't want to use
 		int clientID = snd_seq_client_info_get_client(cinfo);
-		if(clientID < 16) {
-			continue;
-		}
 
 		snd_seq_port_info_set_port(pinfo, -1);
 		// enumerate ports


### PR DESCRIPTION
This PR allows client IDs less than 16 to be listed (thereby allowing MIDI events to be passed to an external program), changes all GZDoom references to ZMusic Program and finally fixes a bug that causes the ALSA backend to freeze if the library is paused.