### PR TITLE
libADLMIDI & libOPNMIDI: Apply the important fix

### DIFF
--- a/thirdparty/adlmidi/adlmidi.cpp
+++ b/thirdparty/adlmidi/adlmidi.cpp
@@ -1414,7 +1414,7 @@ ADLMIDI_EXPORT int adl_generateFormat(struct ADL_MIDIPlayer *device, int sampleC
     ssize_t n_periodCountStereo = 512;
 
     int     left = sampleCount;
-    double  delay = double(sampleCount) / double(setup.PCM_RATE);
+    double  delay = double(sampleCount / 2) / double(setup.PCM_RATE);
 
     while(left > 0)
     {

--- a/thirdparty/opnmidi/opnmidi.cpp
+++ b/thirdparty/opnmidi/opnmidi.cpp
@@ -1134,7 +1134,7 @@ OPNMIDI_EXPORT int opn2_generateFormat(struct OPN2_MIDIPlayer *device, int sampl
     ssize_t n_periodCountStereo = 512;
 
     int     left = sampleCount;
-    double  delay = double(sampleCount) / double(setup.PCM_RATE);
+    double  delay = double(sampleCount / 2) / double(setup.PCM_RATE);
 
     while(left > 0)
     {


### PR DESCRIPTION
Fixed an incorrect timer processing when using a real-time interface.
This bug does directly affect the case of ZMusic which does use of RealTime API of both libraries.