### PR TITLE
libADLMIDI and libOPNMIDI: Fixed an infinite loop caused the stuck

### DIFF
--- a/thirdparty/adlmidi/adlmidi.cpp
+++ b/thirdparty/adlmidi/adlmidi.cpp
@@ -1311,6 +1311,8 @@ ADLMIDI_EXPORT int adl_playFormat(ADL_MIDIPlayer *device, int sampleCount,
     while(left > 0)
     {
         {//...
+            if(setup.delay <= 0.0)
+                setup.delay = double(left / 2) / double(setup.PCM_RATE);
             const double eat_delay = setup.delay < setup.maxdelay ? setup.delay : setup.maxdelay;
             if(hasSkipped)
             {
@@ -1419,6 +1421,8 @@ ADLMIDI_EXPORT int adl_generateFormat(struct ADL_MIDIPlayer *device, int sampleC
     while(left > 0)
     {
         {//...
+            if(delay <= 0.0)
+                delay = double(left / 2) / double(setup.PCM_RATE);
             const double eat_delay = delay < setup.maxdelay ? delay : setup.maxdelay;
             delay -= eat_delay;
             setup.carry += double(setup.PCM_RATE) * eat_delay;

--- a/thirdparty/opnmidi/opnmidi.cpp
+++ b/thirdparty/opnmidi/opnmidi.cpp
@@ -1044,6 +1044,8 @@ OPNMIDI_EXPORT int opn2_playFormat(OPN2_MIDIPlayer *device, int sampleCount,
     while(left > 0)
     {
         {//
+            if(setup.delay <= 0.0)
+                setup.delay = double(left / 2) / double(setup.PCM_RATE);
             const double eat_delay = setup.delay < setup.maxdelay ? setup.delay : setup.maxdelay;
             if(hasSkipped)
             {
@@ -1139,6 +1141,8 @@ OPNMIDI_EXPORT int opn2_generateFormat(struct OPN2_MIDIPlayer *device, int sampl
     while(left > 0)
     {
         {//
+            if(delay <= 0.0)
+                delay = double(left / 2) / double(setup.PCM_RATE);
             const double eat_delay = delay < setup.maxdelay ? delay : setup.maxdelay;
             delay -= eat_delay;
             setup.carry += double(setup.PCM_RATE) * eat_delay;


### PR DESCRIPTION
Recently I've got the report from @drfrag666 that at LZDoom some banks
do cause the dead freeze and that is probably because of the merge
problems. However, after my research, I found the bug at me: in a very
special case, a zero delay value may appear that will cause the stuck.