### PR TITLE
gus timidity+ and wildmidi emulation fix

### DIFF
--- a/source/mididevices/music_timidity_mididevice.cpp
+++ b/source/mididevices/music_timidity_mididevice.cpp
@@ -94,42 +94,44 @@ protected:
 
 void TimidityMIDIDevice::LoadInstruments()
 {
-	if (gusConfig.dmxgus.size())
+	if (gusConfig.reader)
 	{
 		// Check if we got some GUS data before using it.
-		std::string ultradir = getenv("ULTRADIR");
-		if (ultradir.length() || gusConfig.gus_patchdir.length() != 0)
+		std::string ultradir;
+		const char *ret = getenv("ULTRADIR");
+		if (ret) ultradir = std::string(ret);
+		// The GUS put its patches in %ULTRADIR%/MIDI so we can try that
+		if (ultradir.length())
 		{
-			auto psreader = new MusicIO::FileSystemSoundFontReader("");
-			
-			// The GUS put its patches in %ULTRADIR%/MIDI so we can try that
-			if (ultradir.length())
-			{
-				ultradir += "/midi";
-				psreader->add_search_path(ultradir.c_str());
-			}
-			// Load DMXGUS lump and patches from gus_patchdir
-			if (gusConfig.gus_patchdir.length() != 0) psreader->add_search_path(gusConfig.gus_patchdir.c_str());
-			
-			gusConfig.instruments.reset(new Timidity::Instruments(psreader));
-			bool success = gusConfig.instruments->LoadDMXGUS(gusConfig.gus_memsize, (const char*)gusConfig.dmxgus.data(), gusConfig.dmxgus.size()) >= 0;
-			
-			gusConfig.dmxgus.clear();
-			
-			if (success)
-			{
-				gusConfig.loadedConfig = "DMXGUS";
-				return;
-			}
+			ultradir += "/midi";
+			gusConfig.reader->add_search_path(ultradir.c_str());
 		}
-		gusConfig.loadedConfig = "";
-		gusConfig.instruments.reset();
-		throw std::runtime_error("Unable to initialize DMXGUS for GUS MIDI device");
-	}
-	else if (gusConfig.reader)
-	{
-		gusConfig.loadedConfig = gusConfig.readerName;
+		// Load DMXGUS lump and patches from gus_patchdir
+		if (gusConfig.gus_patchdir.length() != 0) gusConfig.reader->add_search_path(gusConfig.gus_patchdir.c_str());
+		
 		gusConfig.instruments.reset(new Timidity::Instruments(gusConfig.reader));
+		gusConfig.loadedConfig = gusConfig.readerName;
+	}
+
+	if (gusConfig.instruments == nullptr)
+	{
+		throw std::runtime_error("No instruments set for GUS device");
+	}
+
+	if (gusConfig.gus_dmxgus && gusConfig.dmxgus.size())
+	{
+		bool success = gusConfig.instruments->LoadDMXGUS(gusConfig.gus_memsize, (const char*)gusConfig.dmxgus.data(), gusConfig.dmxgus.size()) >= 0;
+		gusConfig.reader = nullptr;
+
+		if (!success)
+		{
+			gusConfig.instruments.reset();
+			gusConfig.loadedConfig = "";
+			throw std::runtime_error("Unable to initialize DMXGUS for GUS MIDI device");
+		}
+	}
+	else
+	{
 		bool err = gusConfig.instruments->LoadConfig() < 0;
 		gusConfig.reader = nullptr;
 		
@@ -139,10 +141,6 @@ void TimidityMIDIDevice::LoadInstruments()
 			gusConfig.loadedConfig = "";
 			throw std::runtime_error("Unable to initialize instruments for GUS MIDI device");
 		}
-	}
-	else if (gusConfig.instruments == nullptr)
-	{
-		throw std::runtime_error("No instruments set for GUS device");
 	}
 }
 
@@ -257,20 +255,11 @@ void TimidityMIDIDevice::ComputeOutput(float *buffer, int len)
 
 bool GUS_SetupConfig(const char* args)
 {
-	gusConfig.reader = nullptr;
-	if ((gusConfig.gus_dmxgus && *args == 0) || !stricmp(args, "DMXGUS"))
-	{
-		if (stricmp(gusConfig.loadedConfig.c_str(), "DMXGUS") == 0) return false; // aleady loaded
-		if (gusConfig.dmxgus.size() > 0)
-		{
-			gusConfig.readerName = "DMXGUS";
-			return true;
-		}
-	}
 	if (*args == 0) args = gusConfig.gus_config.c_str();
-	if (stricmp(gusConfig.loadedConfig.c_str(), args) == 0) return false; // aleady loaded
+	if (gusConfig.gus_dmxgus && *args == 0) args = "DMXGUS";
+	//if (stricmp(gusConfig.loadedConfig.c_str(), args) == 0) return false; // aleady loaded
 
-	MusicIO::SoundFontReaderInterface* reader = MusicIO::ClientOpenSoundFont(args, SF_GUS | SF_SF2);
+	MusicIO::SoundFontReaderInterface* reader = MusicIO::ClientOpenSoundFont(args, SF_GUS);
 	if (!reader && MusicIO::fileExists(args))
 	{
 		auto f = MusicIO::utf8_fopen(args, "rb");
@@ -284,6 +273,11 @@ bool GUS_SetupConfig(const char* args)
 				reader = new MusicIO::SF2Reader(args);
 		}
 		if (!reader) reader = new MusicIO::FileSystemSoundFontReader(args, true);
+	}
+
+	if (!reader && gusConfig.gus_dmxgus)
+	{
+		reader = new MusicIO::FileSystemSoundFontReader(args, true);
 	}
 
 	if (reader == nullptr)

--- a/source/mididevices/music_wildmidi_mididevice.cpp
+++ b/source/mididevices/music_wildmidi_mididevice.cpp
@@ -87,15 +87,7 @@ void WildMIDIDevice::LoadInstruments()
 	{
 		wildMidiConfig.loadedConfig = wildMidiConfig.readerName;
 		wildMidiConfig.instruments.reset(new WildMidi::Instruments(wildMidiConfig.reader, SampleRate));
-		int error = wildMidiConfig.instruments->LoadConfig(wildMidiConfig.readerName.c_str());
 		wildMidiConfig.reader = nullptr;
-
-		if (error)
-		{
-			wildMidiConfig.instruments.reset();
-			wildMidiConfig.loadedConfig = "";
-			throw std::runtime_error("Unable to initialize instruments for WildMidi device");
-		}
 	}
 	else if (wildMidiConfig.instruments == nullptr)
 	{
@@ -104,7 +96,9 @@ void WildMIDIDevice::LoadInstruments()
 	instruments = wildMidiConfig.instruments;
 	if (instruments->LoadConfig(nullptr) < 0)
 	{
-		throw std::runtime_error("Unable to load instruments set for WildMidi device");
+		wildMidiConfig.instruments.reset();
+		wildMidiConfig.loadedConfig = "";
+		throw std::runtime_error("Unable to initialize instruments for WildMidi device");
 	}
 }
 

--- a/source/zmusic/configuration.cpp
+++ b/source/zmusic/configuration.cpp
@@ -503,7 +503,7 @@ DLL_EXPORT zmusic_bool ChangeMusicSettingInt(EIntConfigKey key, MusInfo *currSon
 		
 		case zmusic_gus_memsize:
 			ChangeAndReturn(gusConfig.gus_memsize, value, pRealValue);
-			return devType() == MDEV_GUS && gusConfig.gus_dmxgus;
+			return devType() == MDEV_GUS;
 #endif
 #ifdef HAVE_TIMIDITY
 		case zmusic_timidity_modulation_wheel:
@@ -518,15 +518,15 @@ DLL_EXPORT zmusic_bool ChangeMusicSettingInt(EIntConfigKey key, MusInfo *currSon
 
 		case zmusic_timidity_reverb:
 			if (value < 0 || value > 4) value = 0;
-			else TimidityPlus_SetReverb();
 			local_timidity_reverb = value;
+			TimidityPlus_SetReverb();
 			if (pRealValue) *pRealValue = value;
 			return false;
 
 		case zmusic_timidity_reverb_level:
 			if (value < 0 || value > 127) value = 0;
-			else TimidityPlus_SetReverb();
 			local_timidity_reverb_level = value;
+			TimidityPlus_SetReverb();
 			if (pRealValue) *pRealValue = value;
 			return false;
 

--- a/source/zmusic/fileio.h
+++ b/source/zmusic/fileio.h
@@ -320,7 +320,7 @@ public:
 		std::string fullname;
 		if (!fn) 
 		{
-			f = utf8_fopen(mBaseFile.c_str(), "rt");
+			f = utf8_fopen(mBaseFile.c_str(), "rb");
 			fullname = mBaseFile;
 		}
 		else
@@ -330,11 +330,11 @@ public:
 				for(int i = (int)mPaths.size()-1; i>=0; i--)
 				{
 					fullname = mPaths[i] + fn;
-					f = utf8_fopen(fullname.c_str(), "rt");
-					break;
+					f = utf8_fopen(fullname.c_str(), "rb");
+					if (f) break;
 				}
 			}
-			if (!f) f = fopen(fn, "rt");
+			if (!f) f = fopen(fn, "rb");
 		}
 		if (!f) return nullptr;
 		auto tf = new StdioFileReader;


### PR DESCRIPTION
**This PR is linked to the following PR https://github.com/coelckers/gzdoom/pull/1584**

Fixes for gus, timidity+ and wildmidi emulation
- fixed gus emulation not working with `DMXGUS` and `DMXGUSC` lump
- `gus_patchdir` and/or `ULTRADIR` variable can be used to load custom gus patches together with main patches set with `midi_config` (not required when using DMXGUS(C) lump configuration)
- fixed wildmidi emulation not working with collection of GUS patches (resource files)
- `gus_patchdir` and `ULTRADIR` variable can be used whether DMXGUS or timidity configuration is used
- added absolute paths to `FZipPatReader` so we can add custom patches along with the patches present in the resource file by using `gus_patchdir` and/or `ULTRADIR` variable (some custom maps has custom patches that can be added this way without putting them inside the resource file or in the same folder of the configuration file)
- when opening a file with FileSystemSoundFontReader only the last path added to the reader was used, but we can actually add up to two path by setting both `gus_pathdir` and the variable `ULTRADIR`.

To properly test the DMXGUS configuration the `gus_memsize` can be tweaked so the sound will listen differently depending on the memory selected (256 / unlimited sounds way different).

Also to test the `midi_config` and `wildmidi_config` is better to remove paths from the section `SoundfontSearch.Directories` since a valid item is picked from the collection if no value has been set for these options.

A good example of custom `DMXGUSC` lump with custom patches is the map d2xtreme, where the music will sound quiet different whether you use the lump as configuration or the fallback timidity configuration
https://www.doomworld.com/idgames/levels/doom2/d-f/d2xtreme