### PR TITLE
AlsaMIDIDevice: fix potential race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# build artifacts
 /build*
 *.user*
 .DS_Store
+
+# editor/tooling/os files
+*~
+.gdb_history
+.DS_Store
+.vs
+.idea
+.vscode
+.cache
+*.kate-swp
+*.geany


### PR DESCRIPTION
The method SetTempo doesn't seem to have a good use in AlsaMIDIDevice, it can get called from MIDIStreamer at times when the player thread isn't necessarily dealing with the same midi event as the tempo event, so managing tempo events shouldn't have a different priority from other events.