### PR TITLE
CoreMIDIDevice: Wire up CoreMIDIDevice

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -123,8 +123,7 @@ else()
 	find_package(ALSA)
     if(ALSA_FOUND)
 		target_compile_definitions(zmusic-obj INTERFACE HAVE_SYSTEM_MIDI)
-		target_sources(zmusic-obj
-		INTERFACE
+		target_sources(zmusic-obj INTERFACE
 			mididevices/music_alsa_mididevice.cpp
 			mididevices/music_alsa_state.cpp
 		)

--- a/source/mididevices/music_coremidi_mididevice.mm
+++ b/source/mididevices/music_coremidi_mididevice.mm
@@ -36,16 +36,16 @@
 #include <CoreFoundation/CoreFoundation.h>
 #include <mach/mach_time.h>
 #include <CoreAudio/HostTime.h>
-#include <pthread.h>
-#include <unistd.h> // For usleep
 
-#include <queue>
-#include <mutex>
+#include <array>
 #include <condition_variable>
+#include <mutex>
 #include <thread>
 
+#include "../zmusic/zmusic_internal.h"
 #include "mididevice.h"
 #include "zmusic/mididefs.h"
+#include "zmusic/mus2midi.h"
 
 //==========================================================================
 //
@@ -58,7 +58,7 @@
 class CoreMIDIDevice : public MIDIDevice
 {
 public:
-	CoreMIDIDevice(int deviceID);
+	CoreMIDIDevice(int deviceID, bool precache);
 	~CoreMIDIDevice();
 
 	int Open() override;
@@ -67,17 +67,18 @@ public:
 	int GetTechnology() const override;
 	int SetTempo(int tempo) override;
 	int SetTimeDiv(int timediv) override;
-	int StreamOut(MidiHeader *data) override;
-	int StreamOutSync(MidiHeader *data) override;
+	int StreamOut(MidiHeader* data) override;
+	int StreamOutSync(MidiHeader* data) override;
 	int Resume() override;
 	void Stop() override;
 	bool Pause(bool paused) override;
 	bool FakeVolume() override;
 	void InitPlayback() override;
+	void PrecacheInstruments(const uint16_t* instruments, int count) override;
 
 protected:
 	void CalcTickRate();
-	int PlayTick();
+	bool PullEvent();
 
 	// CoreMIDI handles
 	MIDIClientRef midiClient;
@@ -85,28 +86,49 @@ protected:
 	MIDIEndpointRef midiDestination;
 	int deviceID;
 
+	// Event handling
+	enum EventType { TempoEv, MidiMsgEv, NoEvent };
+	union EventMsg
+	{
+		uint32_t Tempo;
+		uint8_t* MidiMsg;
+	};
+	struct CurrentEvent
+	{
+		EventType EventType;
+		EventMsg EventMsg;
+		uint32_t length;
+	};
+	CurrentEvent CurrentEvent;
+	std::array<uint8_t, 3> ShortMsgBuffer;
+	void PrepareTempo(uint32_t tempo);
+	void PrepareMidiMsg(uint8_t* msg, uint32_t length);
+	void HandleCurrentEvent();
+	void SendMIDIData(const uint8_t* data, size_t length, MIDITimeStamp timestamp);
+
 	// Threading
 	std::thread PlayerThread;
-	bool ExitRequested;
-	bool Paused;
+	volatile bool ExitRequested;
 	std::condition_variable EventCV; // Still needed for pause/resume
 	std::mutex EventMutex; // Still needed for pause/resume
 
 	bool isOpen;
+	bool Precache;
 
 	// Timing
 	int Tempo;
+	int InitialTempo;
 	int Division;
-	MIDITimeStamp CurrentEventHostTime; // This will track the host time of the current event being processed.
-	double HostUnitsPerTick; // Conversion factor: Host Time Units per MIDI Tick.
-	MidiHeader *Events; // Linked list of MIDI headers
+	MIDITimeStamp CurrentEvTimeStamp; // This will track the host time of the current event being processed.
+	MIDITimeStamp NextEvTimeStamp;
+	double NanoSecsPerTick; // Conversion factor: Host Time Units per MIDI Tick.
+	MidiHeader* Events; // Linked list of MIDI headers
 	uint32_t Position; // Current position in the MidiHeader buffer
+	uint32_t PositionOffset;
 
 	// Thread functions
 	static void PlayerThreadProc(CoreMIDIDevice* device);
 	void PlayerLoop();
-
-	void SendMIDIData(const uint8_t* data, size_t length, uint64_t timestamp);
 };
 
 //==========================================================================
@@ -115,19 +137,19 @@ protected:
 //
 //==========================================================================
 
-CoreMIDIDevice::CoreMIDIDevice(int deviceID)
+CoreMIDIDevice::CoreMIDIDevice(int deviceID, bool precache)
 	: deviceID(deviceID)
 	, midiClient(0)
 	, midiOutPort(0)
 	, midiDestination(0)
 	, ExitRequested(false)
-	, Paused(false)
 	, isOpen(false)
 	, Tempo(500000)      // Default: 120 BPM (500,000 µs per quarter note)
 	, Division(96)       // Default PPQN
-	, CurrentEventHostTime(0)
+	, CurrentEvTimeStamp(0)
 	, Events(nullptr)
 	, Position(0)
+	, Precache(precache)
 {
 }
 
@@ -161,7 +183,7 @@ int CoreMIDIDevice::Open()
 	status = MIDIClientCreate(CFSTR("GZDoom"), nullptr, nullptr, &midiClient);
 	if (status != noErr)
 	{
-		fprintf(stderr, "CoreMIDI: Failed to create MIDI client (error %d)\n", (int)status);
+		ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: Failed to create MIDI client (error %d)\n", (int)status);
 		return -1;
 	}
 
@@ -169,7 +191,7 @@ int CoreMIDIDevice::Open()
 	status = MIDIOutputPortCreate(midiClient, CFSTR("GZDoom Output"), &midiOutPort);
 	if (status != noErr)
 	{
-		fprintf(stderr, "CoreMIDI: Failed to create output port (error %d)\n", (int)status);
+		ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: Failed to create output port (error %d)\n", (int)status);
 		MIDIClientDispose(midiClient);
 		midiClient = 0;
 		return -1;
@@ -179,7 +201,7 @@ int CoreMIDIDevice::Open()
 	ItemCount destCount = MIDIGetNumberOfDestinations();
 	if (deviceID < 0 || deviceID >= (int)destCount)
 	{
-		fprintf(stderr, "CoreMIDI: Invalid device ID %d (available: %d)\n", deviceID, (int)destCount);
+		ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: Invalid device ID %d (available: %d)\n", deviceID, (int)destCount);
 		MIDIPortDispose(midiOutPort);
 		MIDIClientDispose(midiClient);
 		midiOutPort = 0;
@@ -190,7 +212,7 @@ int CoreMIDIDevice::Open()
 	midiDestination = MIDIGetDestination(deviceID);
 	if (midiDestination == 0)
 	{
-		fprintf(stderr, "CoreMIDI: Failed to get destination for device %d\n", deviceID);
+		ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: Failed to get destination for device %d\n", deviceID);
 		MIDIPortDispose(midiOutPort);
 		MIDIClientDispose(midiClient);
 		midiOutPort = 0;
@@ -205,7 +227,7 @@ int CoreMIDIDevice::Open()
 	{
 		char nameBuf[256];
 		CFStringGetCString(deviceName, nameBuf, sizeof(nameBuf), kCFStringEncodingUTF8);
-		printf("CoreMIDI: Opened device %d: %s\n", deviceID, nameBuf);
+		ZMusic_Printf(ZMUSIC_MSG_DEBUG, "CoreMIDI: Opened device %d: %s\n", deviceID, nameBuf);
 		CFRelease(deviceName);
 	}
 
@@ -227,23 +249,6 @@ void CoreMIDIDevice::Close()
 	// Stop player thread
 	Stop();
 
-	// Wait for thread to exit
-	if (PlayerThread.joinable())
-	{
-		ExitRequested = true;
-		EventCV.notify_all();
-		PlayerThread.join();
-	}
-
-	// Send All Notes Off and Reset All Controllers
-	for (int channel = 0; channel < 16; ++channel)
-	{
-		uint8_t msg1[3] = { (uint8_t)(0xB0 | channel), 123, 0 };
-		SendMIDIData(msg1, 3, 0);  // All Notes Off
-		uint8_t msg2[3] = { (uint8_t)(0xB0 | channel), 121, 0 };
-		SendMIDIData(msg2, 3, 0);  // Reset All Controllers
-	}
-
 	// Dispose CoreMIDI objects
 	if (midiOutPort != 0)
 	{
@@ -259,8 +264,6 @@ void CoreMIDIDevice::Close()
 
 	midiDestination = 0;
 	isOpen = false;
-
-	printf("CoreMIDI: Device closed\n");
 }
 
 //==========================================================================
@@ -301,12 +304,9 @@ int CoreMIDIDevice::GetTechnology() const
 void CoreMIDIDevice::CalcTickRate()
 {
 	// Tempo is in microseconds per quarter note. Division is PPQN.
-	// Host time units per second = AudioGetHostClockFrequency()
-	// Microseconds per second = 1,000,000
-	// Microseconds per tick = Tempo / Division
-	// Host time units per tick = (Microseconds per tick) * (Host time units per second / Microseconds per second)
-	Float64 hostClockFrequency = AudioGetHostClockFrequency();
-	HostUnitsPerTick = ((double)Tempo / (double)Division) * (hostClockFrequency / 1000000.0);
+	// (Tempo / PPQN) what the midi tick time is in microseconds.
+	// CoreAudio and CoreMidi work in nano seconds so multiply by 1000.
+	NanoSecsPerTick = Tempo / Division * 1000;
 }
 
 //==========================================================================
@@ -319,8 +319,7 @@ void CoreMIDIDevice::CalcTickRate()
 
 int CoreMIDIDevice::SetTempo(int tempo)
 {
-	Tempo = tempo;
-	CalcTickRate();
+	InitialTempo = tempo;
 	return 0;
 }
 
@@ -335,7 +334,6 @@ int CoreMIDIDevice::SetTempo(int tempo)
 int CoreMIDIDevice::SetTimeDiv(int timediv)
 {
 	Division = timediv > 0 ? timediv : 96;
-	CalcTickRate();
 	return 0;
 }
 
@@ -347,10 +345,9 @@ int CoreMIDIDevice::SetTimeDiv(int timediv)
 //
 //==========================================================================
 
-int CoreMIDIDevice::StreamOut(MidiHeader *data)
+int CoreMIDIDevice::StreamOut(MidiHeader* data)
 {
-	if (!isOpen)
-		return -1;
+	if (!isOpen) { return -1; };
 
 	data->lpNext = nullptr;
 	if (Events == nullptr)
@@ -360,7 +357,7 @@ int CoreMIDIDevice::StreamOut(MidiHeader *data)
 	}
 	else
 	{
-		MidiHeader **p;
+		MidiHeader** p;
 		for (p = &Events; *p != nullptr; p = &(*p)->lpNext)
 		{
 		}
@@ -377,7 +374,7 @@ int CoreMIDIDevice::StreamOut(MidiHeader *data)
 //
 //==========================================================================
 
-int CoreMIDIDevice::StreamOutSync(MidiHeader *data)
+int CoreMIDIDevice::StreamOutSync(MidiHeader* data)
 {
 	return StreamOut(data);
 }
@@ -392,19 +389,12 @@ int CoreMIDIDevice::StreamOutSync(MidiHeader *data)
 
 int CoreMIDIDevice::Resume()
 {
-	if (!isOpen)
-		return -1;
+	if (!isOpen) { return -1; };
 
 	if (!PlayerThread.joinable())
 	{
 		ExitRequested = false;
-		Paused = false;
 		PlayerThread = std::thread(PlayerThreadProc, this);
-	}
-	else
-	{
-		Paused = false;
-		EventCV.notify_all();
 	}
 
 	return 0;
@@ -420,14 +410,22 @@ int CoreMIDIDevice::Resume()
 
 void CoreMIDIDevice::Stop()
 {
-	if (!isOpen)
-		return;
+	if (!isOpen) { return; }
 
 	if (PlayerThread.joinable())
 	{
 		ExitRequested = true;
 		EventCV.notify_all();
 		PlayerThread.join();
+	}
+
+	// Send All Notes Off and Reset All Controllers
+	for (int channel = 0; channel < 16; ++channel)
+	{
+		uint8_t msg1[3] = { (uint8_t)(0xB0 | channel), 123, 0 };
+		SendMIDIData(msg1, 3, 0);  // All Notes Off
+		uint8_t msg2[3] = { (uint8_t)(0xB0 | channel), 121, 0 };
+		SendMIDIData(msg2, 3, 0);  // Reset All Controllers
 	}
 
 	// Clear event queue
@@ -444,14 +442,7 @@ void CoreMIDIDevice::Stop()
 
 bool CoreMIDIDevice::Pause(bool paused)
 {
-	Paused = paused;
-
-	if (!paused)
-	{
-		EventCV.notify_all();
-	}
-
-	return true;
+	return false; // We don support pausing
 }
 
 //==========================================================================
@@ -464,7 +455,7 @@ bool CoreMIDIDevice::Pause(bool paused)
 
 bool CoreMIDIDevice::FakeVolume()
 {
-	return false;  // No volume support
+	return true;  // No true volume control support, so fake volume
 }
 
 //==========================================================================
@@ -477,10 +468,89 @@ bool CoreMIDIDevice::FakeVolume()
 
 void CoreMIDIDevice::InitPlayback()
 {
-	CurrentEventHostTime = AudioGetCurrentHostTime(); // Initialize with current host time
+	CurrentEvTimeStamp = AudioConvertHostTimeToNanos(AudioGetCurrentHostTime()); // Initialize with current host time
 	Position = 0;
 	Events = nullptr;
+	Tempo = InitialTempo;
 	CalcTickRate();
+}
+
+//==========================================================================
+//
+// CoreMIDIDevice :: PrecacheInstruments
+//
+// This is meant to mirror WinMIDIDevice::PrecacheInstruments
+//
+//==========================================================================
+void CoreMIDIDevice::PrecacheInstruments(const uint16_t* instruments, int count)
+{
+	// Setting snd_midiprecache to false disables this precaching, since it
+	// does involve sleeping for more than a miniscule amount of time.
+	if (!Precache)
+	{
+		return;
+	}
+	uint8_t bank[16] = {0};
+	uint8_t i, chan;
+
+	for (i = 0, chan = 0; i < count; ++i)
+	{
+		uint8_t instr = instruments[i] & 127;
+		uint8_t banknum = (instruments[i] >> 7) & 127;
+		uint8_t percussion = instruments[i] >> 14;
+
+		if (percussion)
+		{
+			if (bank[9] != banknum)
+			{
+				ShortMsgBuffer = { MIDI_CTRLCHANGE | 9, 0, banknum };
+				SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+				bank[9] = banknum;
+			}
+			ShortMsgBuffer = { MIDI_NOTEON | 9, instr, 1 };
+			SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+		}
+		else
+		{ // Melodic
+			if (bank[chan] != banknum)
+			{
+				ShortMsgBuffer = { MIDI_CTRLCHANGE | 9, 0, banknum };
+				SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+				bank[chan] = banknum;
+			}
+			ShortMsgBuffer = { (uint8_t)(MIDI_PRGMCHANGE | chan), (uint8_t)instruments[i] };
+			SendMIDIData(ShortMsgBuffer.data(), 2, 0);
+			ShortMsgBuffer = { (uint8_t)(MIDI_NOTEON | chan), 60, 1 };
+			SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+			if (++chan == 9)
+			{ // Skip the percussion channel
+				chan = 10;
+			}
+		}
+		// Once we've got an instrument playing on each melodic channel, sleep to give
+		// the driver time to load the instruments. Also do this for the final batch
+		// of instruments.
+		if (chan == 16 || i == count - 1)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(250));
+			for (chan = 15; chan-- != 0; )
+			{
+				// Turn all notes off
+				ShortMsgBuffer = { (uint8_t)(MIDI_CTRLCHANGE | chan), 123, 0 };
+				SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+			}
+			// And now chan is back at 0, ready to start the cycle over.
+		}
+	}
+	// Make sure all channels are set back to bank 0.
+	for (i = 0; i < 16; ++i)
+	{
+		if (bank[i] != 0)
+		{
+			ShortMsgBuffer = { MIDI_CTRLCHANGE | 9, 0, 0 };
+			SendMIDIData(ShortMsgBuffer.data(), 3, 0);
+		}
+	}
 }
 
 //==========================================================================
@@ -491,65 +561,86 @@ void CoreMIDIDevice::InitPlayback()
 //
 //==========================================================================
 
-int CoreMIDIDevice::PlayTick()
+bool CoreMIDIDevice::PullEvent()
 {
-	if (Events == nullptr && Callback)
-	{
-		// All events in the current MidiHeader processed, request next buffer
+	if (!Events && Callback)
+	{	// No events in the current MidiHeader, request next buffer
 		Callback(CallbackData);
 	}
 
-	if (Events == nullptr)
-	{
-		// No events available to process.
-		return 0;
+	if (!Events)
+	{	// No events available to process.
+		return false;
+	}
+
+	if (Position >= Events->dwBytesRecorded)
+	{	// All events in the "Events" buffer were used, point to next buffer
+		Events = Events->lpNext;
+		Position = 0;
+		if (Callback)
+		{	// This ensures that we always have 2 unused buffers after 1 is used up.
+			// omit this nested "if" block if you want to use up the 2 buffers before requesting new buffers
+			Callback(CallbackData);
+		}
+	}
+
+	if (!Events)
+	{	// No events in the new buffer
+		return false;
 	}
 
 	// Read the delta time (first 4 bytes of the event)
-	uint32_t *event_ptr = (uint32_t *)(Events->lpData + Position);
-	uint32_t midi_delta_ticks = event_ptr[0]; // Assuming delta time is the first uint32_t
+	uint32_t* event_ptr = (uint32_t*)(Events->lpData + Position);
+	uint32_t tick_delta = event_ptr[0]; // Assuming delta time is the first uint32_t
 
 	// Advance CurrentEventHostTime based on delta ticks.
-	// This timestamp will be used for the current event.
-	CurrentEventHostTime += (MIDITimeStamp)(midi_delta_ticks * HostUnitsPerTick);
+	// This timestamp will be used for the current event, accurate to the 0.5 millisecond.
+	NextEvTimeStamp = CurrentEvTimeStamp + tick_delta * NanoSecsPerTick;
 
-	uint32_t len; // Length of the current MIDI event in bytes
 	uint32_t midi_event_type_param = event_ptr[2]; // This is the actual MIDI event or meta-event info
 
 	if (midi_event_type_param < 0x80000000) // Short message (midi_event_type_param is the combined status/data bytes)
 	{
-		len = 12; // 4 bytes delta time, 4 bytes reserved, 4 bytes MIDI message (up to 3 bytes + padding)
+		PositionOffset = 12; // 4 bytes delta time, 4 bytes reserved, 4 bytes MIDI message (up to 3 bytes + padding)
 	}
 	else // Long message or meta-event (midi_event_type_param holds type and parameter length)
 	{
-		len = 12 + ((MEVENT_EVENTPARM(midi_event_type_param) + 3) & ~3);
+		PositionOffset = 12 + ((MEVENT_EVENTPARM(midi_event_type_param) + 3) & ~3);
 	}
 
-	if (MEVENT_EVENTTYPE(midi_event_type_param) == MEVENT_TEMPO)
+	switch (MEVENT_EVENTTYPE(midi_event_type_param))
 	{
+	case MEVENT_TEMPO:
 		// Tempo change event, update our internal calculation for future events
-		SetTempo(MEVENT_EVENTPARM(midi_event_type_param));
+		PrepareTempo(MEVENT_EVENTPARM(midi_event_type_param));
+		break;
+	case MEVENT_LONGMSG:
+	{	// Long MIDI message (SysEx, etc.), data starts after event_ptr[3]
+		int long_msg_len = MEVENT_EVENTPARM(midi_event_type_param);
+		uint8_t* long_msg_data = (uint8_t*)&event_ptr[3];
+		// Ensure valid sysex message
+		if (long_msg_len > 2 && long_msg_data[0] == 0xF0 && long_msg_data[long_msg_len - 1] == 0xF7)
+		{
+			PrepareMidiMsg(long_msg_data, long_msg_len);
+			break;
+		}
 	}
-	else if (MEVENT_EVENTTYPE(midi_event_type_param) == MEVENT_LONGMSG)
-	{
-		// Long MIDI message (SysEx, etc.), data starts after event_ptr[3]
-		SendMIDIData((uint8_t *)&event_ptr[3], MEVENT_EVENTPARM(midi_event_type_param), CurrentEventHostTime);
-	}
-	else if (MEVENT_EVENTTYPE(midi_event_type_param) == 0) // Short MIDI message (note on/off, control change, etc.)
+	case 0: // Short MIDI message (note on/off, control change, etc.)
 	{
 		// midi_event_type_param contains the 1, 2, or 3 byte MIDI message
-		uint8_t msg[3] = { (uint8_t)(midi_event_type_param & 0xff),
-						   (uint8_t)((midi_event_type_param >> 8) & 0xff),
-						   (uint8_t)((midi_event_type_param >> 16) & 0xff) };
+		ShortMsgBuffer = { (uint8_t)(midi_event_type_param & 0xff), // Status
+						   (uint8_t)((midi_event_type_param >> 8) & 0xff), // Data 1
+						   (uint8_t)((midi_event_type_param >> 16) & 0xff) }; // Data 2
+
 		int msgLen = 0;
-		if (msg[0] >= 0xF0) // System messages
+		if (ShortMsgBuffer[0] >= 0xF0) // System messages
 		{
-			if (msg[0] == 0xF0 || msg[0] == 0xF7) msgLen = 1; // Start/Stop/Continue/Timing/Active Sensing/Reset (1 byte)
-			else if (msg[0] == 0xF1 || msg[0] == 0xF3) msgLen = 2; // Time Code Quarter Frame, Song Select (2 bytes)
-			else if (msg[0] == 0xF2) msgLen = 3; // Song Position Pointer (3 bytes)
+			if (ShortMsgBuffer[0] == 0xF0 || ShortMsgBuffer[0] == 0xF7) msgLen = 1; // Start/Stop/Continue/Timing/Active Sensing/Reset (1 byte)
+			else if (ShortMsgBuffer[0] == 0xF1 || ShortMsgBuffer[0] == 0xF3) msgLen = 2; // Time Code Quarter Frame, Song Select (2 bytes)
+			else if (ShortMsgBuffer[0] == 0xF2) msgLen = 3; // Song Position Pointer (3 bytes)
 			else msgLen = 1; // Default to 1 for other unknown system messages
 		}
-		else if (msg[0] >= 0xC0 && msg[0] < 0xE0) // Program Change or Channel Aftertouch (2 bytes)
+		else if (ShortMsgBuffer[0] >= 0xC0 && ShortMsgBuffer[0] < 0xE0) // Program Change or Channel Aftertouch (2 bytes)
 		{
 			msgLen = 2;
 		}
@@ -557,22 +648,16 @@ int CoreMIDIDevice::PlayTick()
 		{
 			msgLen = 3;
 		}
-		SendMIDIData(msg, msgLen, CurrentEventHostTime);
+		PrepareMidiMsg(ShortMsgBuffer.data(), msgLen);
+		break;
 	}
-	// Other MEVENT_EVENTTYPE values (e.g., MEVENT_NOTEON, MEVENT_NOTEOFF etc. from WinMIDI)
-	// are not directly used here; the raw MIDI message is parsed from event_ptr[2]
+	default:
+		CurrentEvent.EventType = NoEvent;
+	}
 
-	Position += len;
-	if (Position >= Events->dwBytesRecorded)
-	{
-		// Current MidiHeader buffer exhausted, move to the next one
-		Events = Events->lpNext;
-		Position = 0;
-	}
-	
 	// Indicate that an event was processed and potentially more are available in the current tick.
 	// The PlayerLoop will decide when to call PlayTick again.
-	return 1;
+	return true;
 }
 
 //==========================================================================
@@ -585,7 +670,6 @@ int CoreMIDIDevice::PlayTick()
 
 void CoreMIDIDevice::PlayerThreadProc(CoreMIDIDevice* device)
 {
-	pthread_setname_np("CoreMIDI Player");
 	device->PlayerLoop();
 }
 
@@ -599,28 +683,56 @@ void CoreMIDIDevice::PlayerThreadProc(CoreMIDIDevice* device)
 
 void CoreMIDIDevice::PlayerLoop()
 {
-	while (!ExitRequested)
+	std::unique_lock<std::mutex> lock(EventMutex);
+	std::chrono::nanoseconds buffer_time_limit(40000000);
+	// Process all available events and schedule them with CoreMIDI
+	while (!ExitRequested) //while (Events != nullptr && !Paused && !ExitRequested)
 	{
-		// Process all available events and schedule them with CoreMIDI
-		while (Events != nullptr && !Paused && !ExitRequested)
+		if (!PullEvent())
 		{
-			// PlayTick returns 1 if an event was processed.
-			// It will continue to be called until Events becomes nullptr.
-			PlayTick();
+			EventCV.wait_for(lock, buffer_time_limit);
+			continue;
 		}
 
-		// After processing all currently available events, or if paused/exit requested,
-		// wait for new data, unpause, or exit signal.
-		std::unique_lock<std::mutex> lock(EventMutex);
-		EventCV.wait(lock, [&]{
-			return Paused || ExitRequested || Events != nullptr; // Wake up if paused, exit requested, or new events available
-		});
-
-		// If paused, just wait until unpaused or exit requested
-		while (Paused && !ExitRequested)
+		std::chrono::nanoseconds next_ev_time_delta(NextEvTimeStamp - AudioConvertHostTimeToNanos(AudioGetCurrentHostTime()));
+		std::chrono::nanoseconds schedule_time = next_ev_time_delta - buffer_time_limit;
+		if (schedule_time >= buffer_time_limit)
 		{
-			EventCV.wait(lock);
+			// Try to keep events under 2x time limit
+			EventCV.wait_for(lock, schedule_time);
+			continue;
 		}
+		CurrentEvTimeStamp = NextEvTimeStamp;
+		Position += PositionOffset;
+		HandleCurrentEvent();
+	}
+	std::this_thread::sleep_for(buffer_time_limit * 2);
+}
+
+void CoreMIDIDevice::PrepareTempo(const uint32_t tempo)
+{
+	CurrentEvent.EventType = TempoEv;
+	CurrentEvent.EventMsg.Tempo = tempo;
+}
+void CoreMIDIDevice::PrepareMidiMsg(uint8_t* msg, uint32_t length)
+{
+	CurrentEvent.EventType = MidiMsgEv;
+	CurrentEvent.EventMsg.MidiMsg = msg;
+	CurrentEvent.length = length;
+}
+
+void CoreMIDIDevice::HandleCurrentEvent()
+{
+	switch (CurrentEvent.EventType)
+	{
+	case TempoEv:
+		Tempo = CurrentEvent.EventMsg.Tempo;
+		CalcTickRate();
+		break;
+	case MidiMsgEv:
+		SendMIDIData(CurrentEvent.EventMsg.MidiMsg, CurrentEvent.length, AudioConvertNanosToHostTime(CurrentEvTimeStamp));
+		break;
+	default:
 	}
 }
 
@@ -632,7 +744,7 @@ void CoreMIDIDevice::PlayerLoop()
 //
 //==========================================================================
 
-void CoreMIDIDevice::SendMIDIData(const uint8_t* data, size_t length, uint64_t timestamp)
+void CoreMIDIDevice::SendMIDIData(const uint8_t* data, size_t length, MIDITimeStamp timestamp)
 {
 	if (!isOpen || midiOutPort == 0 || midiDestination == 0)
 		return;
@@ -657,7 +769,7 @@ void CoreMIDIDevice::SendMIDIData(const uint8_t* data, size_t length, uint64_t t
 		}
 		catch (const std::bad_alloc&)
 		{
-			fprintf(stderr, "CoreMIDI: Failed to allocate memory for large MIDI message.\n");
+			ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: Failed to allocate memory for large MIDI message.\n");
 			return;
 		}
 	}
@@ -679,13 +791,13 @@ void CoreMIDIDevice::SendMIDIData(const uint8_t* data, size_t length, uint64_t t
 		OSStatus status = MIDISend(midiOutPort, midiDestination, packetList);
 		if (status != noErr)
 		{
-			fprintf(stderr, "CoreMIDI: MIDISend failed (error %d)\n", (int)status);
+			ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: MIDISend failed (error %d)\n", (int)status);
 		}
 	}
 	else
 	{
 		// This should ideally not happen with dynamic allocation, but we keep the check for safety.
-		fprintf(stderr, "CoreMIDI: MIDIPacketListAdd failed unexpectedly.\n");
+		ZMusic_Printf(ZMUSIC_MSG_ERROR, "CoreMIDI: MIDIPacketListAdd failed unexpectedly.\n");
 	}
 }
 
@@ -701,5 +813,5 @@ void CoreMIDIDevice::SendMIDIData(const uint8_t* data, size_t length, uint64_t t
 
 MIDIDevice* CreateCoreMIDIDevice(int mididevice)
 {
-	return new CoreMIDIDevice(mididevice);
+	return new CoreMIDIDevice(mididevice, miscConfig.snd_midiprecache);
 }

--- a/source/musicformats/music_midi.cpp
+++ b/source/musicformats/music_midi.cpp
@@ -284,6 +284,8 @@ MIDIDevice *MIDIStreamer::CreateMIDIDevice(EMidiDevice devtype, int samplerate)
 				dev = CreateWinMIDIDevice(std::max(0, miscConfig.snd_mididevice));
 #elif __linux__
                 dev = CreateAlsaMIDIDevice(std::max(0, miscConfig.snd_mididevice));
+#elif __APPLE__
+				dev = CreateCoreMIDIDevice(std::max(0, miscConfig.snd_mididevice));
 #endif
 				break;
 #endif

--- a/source/zmusic/configuration.cpp
+++ b/source/zmusic/configuration.cpp
@@ -45,6 +45,11 @@
 #include "midiconfig.h"
 #include "mididevices/music_alsa_state.h"
 
+#ifdef __APPLE__
+#include <CoreMIDI/CoreMIDI.h>
+#include <CoreFoundation/CoreFoundation.h>
+#endif
+
 #ifdef HAVE_TIMIDITY
 #include "timidity/timidity.h"
 #include "timiditypp/timidity.h"
@@ -164,6 +169,7 @@ DLL_EXPORT void ZMusic_SetDmxGus(const void* data, unsigned len)
 #endif
 }
 
+// FIXME: This function is unused, is it worth keeping?
 int ZMusic_EnumerateMidiDevices()
 {
 #ifdef HAVE_SYSTEM_MIDI
@@ -243,6 +249,18 @@ struct MidiDeviceList
 				ZMusicMidiOutDevice mdev = { outbuf, int(id), caps.wTechnology };
 				devices.push_back(mdev);
 			}
+		}
+#elif __APPLE__
+		for (int i = 0; i < MIDIGetNumberOfDestinations(); i++)
+		{
+			uint32_t endpoint = MIDIGetDestination(i);
+			if (!endpoint)
+			{
+				continue;
+			}
+			CFStringRef cfName;
+			MIDIObjectGetStringProperty(endpoint, kMIDIPropertyName, &cfName);
+			devices.push_back({ strdup(CFStringGetCStringPtr(cfName, kCFStringEncodingUTF8)), i, MIDIDEV_MAPPER });
 		}
 #endif
 #endif


### PR DESCRIPTION
This works as in it plays midi through fluidsynth virtual midi devices in the limited testing I did.
I made this in a mac VM and it was an abysmal experience so parts might be rushed.
Maybe this should be merged for people who want to play midi through midi devices and bugs if they were to appear will be squashed then.